### PR TITLE
general: fix tip dist build

### DIFF
--- a/dist.sh
+++ b/dist.sh
@@ -29,8 +29,9 @@ then
 	 # We need to update our dependencies (as the main module)
 	 # to the tip of CUE
 	 go get cuelang.org/go@master
-	 ./_scripts/revendorToolsInternal.sh
-	 go generate ./...
+	 bash ./_scripts/revendorToolsInternal.sh
+	 go mod tidy
+	 go generate $(go list ./... | grep -v cuelang_org_go_internal)
 fi
 
 # Use the cache of playground node_modules


### PR DESCRIPTION
When running dist for tip, we upgrade the version of CUE used by the
playground. This requires us to re-run the vendor of internal CUE
packages.

However, whilst the script itself has executable permissions, when we
run the dist.sh script in the context of a cuelang.org website build, we
are in fact running the result of an unzip module version. All files in
such a module zip are 0444 before umask, hence we need to explicitly
invoke the script as an argument to bash